### PR TITLE
Add deno support

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,29 @@
+name: deno
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Lint wrapper
+        run: deno lint deno/
+
+      - name: Format check wrapper
+        run: deno fmt --check deno/
+
+      - name: Run envinfo via Deno (JSON)
+        run: deno run --allow-run --allow-read --allow-env --allow-sys deno/envinfo.ts --system --binaries --json
+

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ To use as a library in another project:
 npm install envinfo || yarn add envinfo
 ```
 
+## Deno Usage
+
+Run directly with Deno (no Node install required):
+
+```sh
+deno run --allow-run --allow-read --allow-env --allow-sys deno/envinfo.ts --system --binaries
+```
+
+Or add tasks via `deno.json` and run:
+
+```sh
+deno task envinfo --system --binaries --json
+```
+
 ## CLI Usage
 
 `envinfo` || `npx envinfo`

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,10 @@
+{
+  "tasks": {
+    "fmt": "deno fmt deno/",
+    "lint": "deno lint deno/",
+    "envinfo": "deno run --allow-run --allow-read --allow-env --allow-sys deno/envinfo.ts"
+  },
+  "compilerOptions": {
+    "lib": ["deno.ns", "dom", "dom.iterable"]
+  }
+}

--- a/deno/envinfo.ts
+++ b/deno/envinfo.ts
@@ -1,0 +1,20 @@
+// Deno wrapper for envinfo using Node compatibility and npm: specifiers
+// Permissions required: --allow-run --allow-read --allow-env --allow-sys
+
+// Import CommonJS packages via Deno's Node/npm compatibility
+import minimist from "npm:minimist@^1.2.8";
+import envinfoCjs from "npm:envinfo@7";
+
+// Normalize CommonJS default export interop
+// deno-lint-ignore no-explicit-any
+const envinfo: any = (envinfoCjs as any).default ?? (envinfoCjs as any);
+
+// Parse CLI args to match Node's minimist semantics
+const argv = minimist(Deno.args);
+// Ensure console output is enabled by default for CLI usage
+(argv as Record<string, unknown>).console = true;
+
+// Run the existing CLI entry exported by envinfo
+// It prints to console if argv.console is true, and also returns the formatted string
+await envinfo.cli(argv);
+


### PR DESCRIPTION
Add Deno support to allow `envinfo` to be run directly via Deno's Node compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-023abdd9-6c00-4663-ad77-00c8d5bb135a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-023abdd9-6c00-4663-ad77-00c8d5bb135a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

