### PR TITLE
feat: add jq utility helper

### DIFF
--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -117,6 +117,14 @@ module.exports = {
     ]).then(v => utils.determineFound('OpenSSL', v[0], v[1]));
   },
 
+  getjqInfo: () => {
+    utils.log('trace', 'getjqInfo');
+    return Promise.all([
+      utils.run('jq --version').then(utils.findVersion),
+      utils.which('jq'),
+    ]).then(v => utils.determineFound('jq', v[0], v[1]));
+  },
+
   getccacheInfo: () => {
     utils.log('trace', 'getccacheInfo');
     return Promise.all([

--- a/src/presets.js
+++ b/src/presets.js
@@ -23,6 +23,7 @@ module.exports = {
       'GCC',
       'Git',
       'Git LFS',
+      'jq',
       'Clang',
       'Ninja',
       'Mercurial',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `jq` utility helper that reports the installed version and path
- include `jq` in the default Utilities preset so it appears in standard envinfo output

## Testing
- `node src/cli.js --helper jqInfo`
- `node src/cli.js --utilities`
- `yarn test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-821a5e2c-87c1-48e3-9a68-e457cff3b015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-821a5e2c-87c1-48e3-9a68-e457cff3b015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

