### PR TITLE
Remove R install from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ install:
 test_script:
   - node --version
   - choco install ffmpeg
-  - choco install r.project -version 3.6.0
-  - set RPATH=C:\Program Files\R\R-3.6.0\bin\x64
-  - set PATH=%RPATH%;%PATH%
   - node src/cli.js
   - SET ENVINFO_DEBUG=trace
   - npm run build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the `r.project` Chocolatey install from AppVeyor
- remove the R-specific `RPATH`/`PATH` setup that was only needed for that install
- leave the rest of the Windows CI flow unchanged

## Testing
- not run (CI configuration change only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2a64469-f661-482f-b2d0-48ccb8d0bac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2a64469-f661-482f-b2d0-48ccb8d0bac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

